### PR TITLE
Fixed embedding, code cleanup, and improved initialization

### DIFF
--- a/review_process/version_1.1/09_tutorial_06/tutorial_06.tex
+++ b/review_process/version_1.1/09_tutorial_06/tutorial_06.tex
@@ -42,7 +42,7 @@ We will learn how to install GROMOS with the interface to SchNetPack, generate a
 
 \subsubsection{Installation} \label{chap:burnn_install}
 \paragraph{Prerequisites}
-To compile and install GROMOS with the interface to SchNetPack (spk) to run NN models, you first need to have installed SchNetPack and the pybind11 library \cite{pybind11}. The interface uses the pybind11 library to call the model prediction functions in the Python code of SchNetPack. To install the SchNetPack and pybind11 library on your system, please follow their respective installation instructions. The tested version of SchNetPack is 1.0.0 and pybind11 v2.6.2.
+To compile and install GROMOS with the interface to SchNetPack (spk) to run NN models, you first need to have installed SchNetPack and the pybind11 library \cite{pybind11}. The interface uses the pybind11 library to call the model prediction functions in the Python code of SchNetPack. To install the SchNetPack and pybind11 library on your system, please follow their respective installation instructions. The tested version of SchNetPack is \href{https://github.com/atomistic-machine-learning/schnetpack/releases/tag/v1.0.1}{v1.0.1} and pybind11 v2.6.2.
 
 \paragraph{GPU acceleration}
 This part is optional to improve the efficiency of the simulations. The tasks in this tutorial are small enough to be run CPU-only in a reasonable time. For the production runs this is inefficient since the training and evaluation of models on a GPU is usually manifold faster. NN/MM MD simulations in GROMOS profit from this as well. Setting up your system to support the GPU acceleration is strongly architecture specific and is dependent on the installed CUDA and Pytorch versions. Please follow the installation instructions of CUDA and Pytorch to run tasks with the GPU acceleration.
@@ -270,14 +270,14 @@ In addition to the separate input file, the \href{https://github.com/LierB/gromo
 QMMM
 # NTQMMM NTQMSW RCUTQM NTWQMMM QMLJ QMCON      
  MMSCALE
-       1      5    1.4       0    0     0
+      -1      5    1.4       0    0     0
     -1.0
 END
 \end{lstlisting}
 
 Most of the parameters are only relevant for conventional QM/MM simulations and will therefore not be explained in detail.
 
-QM/MM hybrid simulations (with mechanical embedding) are enabled by setting the first parameter \texttt{NTQMMM=1}. The interactions between the inner region and the outer region are essentially on the mechanical embedding level. \texttt{NTQMSW} determines which software will be used for the QM calculation. The SchNetPack corresponds to \texttt{NTQMSW=5}. The cutoff determined by \texttt{RCUTQM} is only relevant for electrostatic or polarizable embeddings and for \texttt{NTQMMM=1} it is ignored. \texttt{NTWQMMM} can be used if QM/MM related data should be written to a separate trajectory every n-th step. For BuRNN simulations we do not want to calculate LJ for pairs of atoms within the inner region \texttt{QMLJ=0}. Constraining the bond lengths in the QM zone is optional (\texttt{QMCON}). With \texttt{MMSCALE} we can scale MM charges (by a scaling factor), but if \texttt{MMSCALE<0} no scaling is applied.
+QM/MM hybrid simulations (in mechanical embedding with constant charges) are enabled by setting the first parameter \texttt{NTQMMM=-1}. The interactions between the inner region and the outer region are essentially on the mechanical embedding level. \texttt{NTQMSW} determines which software will be used for the QM calculation. The SchNetPack corresponds to \texttt{NTQMSW=5}. The cutoff determined by \texttt{RCUTQM} is only relevant for electrostatic or polarizable embeddings, while for mechanical embedding (\texttt{NTQMMM=+-1}) it is ignored. \texttt{NTWQMMM} can be used if QM/MM related data should be written to a separate trajectory every n-th step. For BuRNN simulations we do not want to calculate LJ for pairs of atoms within the inner region \texttt{QMLJ=0}. Constraining the bond lengths in the QM zone is optional (\texttt{QMCON}). With \texttt{MMSCALE} we can scale MM charges (by a scaling factor), but if \texttt{MMSCALE<0} no scaling is applied.
 
 In analogy to Tutorial 1 job scripts can be generated with the \texttt{mk\_script} program. The argument file \href{https://github.com/LierB/gromos_tutorial_livecoms/blob/burnn_tutorial_rc/tutorial_files/t_06/md_burnn/md_mk_script.arg}{\texttt{md\_mk\_script.arg}} is provided. Finally, you can execute the run files.
 

--- a/tutorial_files/t_06/md_burnn/env.sh
+++ b/tutorial_files/t_06/md_burnn/env.sh
@@ -3,8 +3,13 @@ SPK_ENV=spk
 ## Specify the number of OpenMP threads
 OMP_NUM_THREADS=8
 
+if ! command -v conda &> /dev/null; then
+    echo "Error: Conda command not found. Please install Conda or ensure it is added to your PATH."
+    echo "Visit https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html for installation instructions."
+    exit 1
+fi
 
-. ${CONDA_PREFIX}/etc/profile.d/conda.sh
+eval "$(conda shell.bash activate)"
 conda activate ${SPK_ENV}
 export OMP_NUM_THREADS
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CONDA_PREFIX}/envs/${SPK_ENV}/lib

--- a/tutorial_files/t_06/train_dataset_tutorial/spk_run.py
+++ b/tutorial_files/t_06/train_dataset_tutorial/spk_run.py
@@ -124,13 +124,6 @@ def main(args):
     train_args = setup_run(args)
 
     device = torch.device("cuda" if args.cuda else "cpu")
-    # load MLMM indices
-    #if args.mlmm is not None:
-        #mlmm_indices = get_indices_mlmm(args.mlmm) 
-        #train_args.mlmm_indices = mlmm_indices
-    #else:
-        #args.mlmm_indices = None
-        #train_args.mlmm_indices = None
  
     # get dataset
     environment_provider = get_environment_provider(train_args, device=device)


### PR DESCRIPTION
1. CONDA_PREFIX is usually not defined, if there is no conda initialized yet. Changed to initialization according the official documentantion.
1. Added link to Schnetpack v1.0.1
1. Changed `NTQMMM` to `-1` to employ mechanical embedding with **constant charges**.